### PR TITLE
Corrected link to @markdotto's GitHub buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
                 <script type="text/javascript">
                   (function() {
                       var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true; po.src = 'https://apis.google.com/js/plusone.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s); })(); </script>
-                <iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=adityab&repo=Awwation&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
-                <iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=adityab&repo=Awwation&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe>
+                <iframe src="http://ghbtns.com/github-btn.html?user=adityab&repo=Awwation&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
+                <iframe src="http://ghbtns.com/github-btn.html?user=adityab&repo=Awwation&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe>
                 <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://adityab.github.com/Awwation/" data-text="Awwation - A zooming HTML5 + SVG Prezi clone!" data-via="aditya_bhatt">Tweet</a>
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
                 <!-- Auto-detect URL of current page and title if necessary -->


### PR DESCRIPTION
otherwise, the page wouldn't finish loading and would just redirect to a blank GitHub 404 page - not even the fun one

the github-buttons issue is here: https://github.com/markdotto/github-buttons/issues/23

Visit awwation.com to see the horrendous messness before this wonderful change - a "For security reasons, framing is not allowed" message pops up, supposedly from markdotto.github.com
